### PR TITLE
Fix table selector for scraping

### DIFF
--- a/truehero.py
+++ b/truehero.py
@@ -33,7 +33,7 @@ def scrape_data():
         response.raise_for_status()
         soup = BeautifulSoup(response.text, 'html.parser')
 
-        game_table = soup.find('table', {'class': 'rounded centered cellpadding1 hovertable striped'})
+        game_table = soup.find('table', class_=lambda c: c and 'hovertable' in c.split())
         
         if game_table:
             game_links = game_table.find_all('a', href=True)


### PR DESCRIPTION
## Summary
- search for the `hovertable` table using a lambda so class order doesn't matter

## Testing
- `python truehero.py <<'EOF'
1
EOF` *(fails: 503 Server Error)*

------
https://chatgpt.com/codex/tasks/task_e_684285a57e48833190fb11d1b272e44e